### PR TITLE
[FEATURE] Chat API에 카드뉴스 기반 RAG 연동 구현

### DIFF
--- a/app/ml/collect_url.py
+++ b/app/ml/collect_url.py
@@ -5,7 +5,7 @@ import json
 import os
 import re
 
-# === NAVER API 인증 ===
+# NAVER API 인증
 CLIENT_ID = os.getenv("NAVER_CLIENT_ID")
 CLIENT_SECRET = os.getenv("NAVER_CLIENT_SECRET")
 
@@ -60,7 +60,7 @@ def collect_links(json_result: list) -> list[str]:
     ))
 
 
-# URL 수집 (Chat/RAG)
+# URL 수집 (RAG)
 def get_urls_for_keywords(keywords: list[str], max_per_query: int = 200, display_per_page: int = 100) -> list[str]:
     url_list = []
     for q in keywords:

--- a/app/ml/rag.py
+++ b/app/ml/rag.py
@@ -96,7 +96,7 @@ generator = pipeline(
     "text-generation",
     model=model,
     tokenizer=tokenizer,
-    max_new_tokens=256,
+    max_new_tokens=512,
     temperature=0.3,
     repetition_penalty=1.05,
     top_k=20,

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -3,9 +3,10 @@ from typing import List
 from app.ml import rag
 from app.utils.user_command_logger import CommandPatternLogger
 from app.models.chat import ChatRequest, ChatResponse
-from app.ml.collect_url import extract_keywords, get_urls_for_keywords
+from app.ml.collect_url import extract_keywords, get_news_for_keywords
 from newspaper import Article
 from langchain.text_splitter import RecursiveCharacterTextSplitter
+
 
 def _is_stock_chunk(text: str) -> bool:
     if not text:
@@ -17,21 +18,30 @@ def _is_stock_chunk(text: str) -> bool:
     ]
     return any(k in text.lower() for k in keys)
 
+def _clean_title(title: str) -> str:
+    """뉴스 제목에서 HTML 태그 제거"""
+    return re.sub(r"<[^>]+>", "", title or "").strip()
+
 def _postprocess_chatty(text: str) -> str:
     t = re.sub(r"(?m)^\s*([\-–•\*\d]+\s*[.)]?)\s*", "", text)
     t = re.sub(r"\s*\n+\s*", " ", t).strip()
     return " ".join(re.split(r"(?<=[.!?。])\s+", t)[:3])
 
+# 질문에서 키워드 추출 → 네이버 뉴스 수집 → 기사 파싱 → 벡터스토어 저장 (메타데이터 포함: url, title, date)
 async def _fetch_and_store_news(question: str, duration_seconds: int = 60):
     keys = extract_keywords(question or "") or [question]
-    urls = get_urls_for_keywords(keys, max_per_query=200)
+    news_items = get_news_for_keywords(keys, days=14, max_links=200)
 
     seen_hashes = set()
     start = time.time()
 
-    for url in urls:
+    for item in news_items:
         if time.time() - start > duration_seconds:
+            print(f"[DEBUG] 수집 중단: {duration_seconds}초 초과")
             break
+        url = item.get("link")
+        title = _clean_title(item.get("title") or "")
+        date = item.get("date") or ""
         try:
             article = Article(url)
             article.download(); article.parse()
@@ -44,38 +54,61 @@ async def _fetch_and_store_news(question: str, duration_seconds: int = 60):
             seen_hashes.add(h)
 
             chunks = RecursiveCharacterTextSplitter(
-                chunk_size=500, chunk_overlap=0
+                chunk_size=800, chunk_overlap=100
             ).split_text(text)
+
             if chunks:
-                rag.vectorstore.add_texts(chunks, metadatas=[{"source": url} for _ in chunks])
+                rag.vectorstore.add_texts(
+                    chunks,
+                    metadatas=[{"source": url, "title": title, "date": date} for _ in chunks]
+                )
+                print(f"[DEBUG] 저장됨: {title} | {date} | {url} | {len(chunks)} 청크")
         except Exception:
+            print(f"[ERROR] 기사 처리 실패: {url} | {e}")
             pass
         await asyncio.sleep(0)
 
+# RAG 기반 챗봇 처리
 async def process_chat(req: ChatRequest, user_id: str) -> ChatResponse:
     t0 = time.time()
     logger = CommandPatternLogger(user_id=user_id)
     is_similar = await logger.process_command(req.message)
 
+    # 뉴스 수집
     if req.enable_news_collect:
         duration = 10 if is_similar else 60
         await _fetch_and_store_news(req.message, duration_seconds=duration)
 
+    # 검색 및 필터링
     retriever = rag.vectorstore.as_retriever(search_kwargs={"k": req.top_k})
     docs = retriever.invoke(req.message)
+    print(f"[DEBUG] 검색된 문서 수: {len(docs)}")
     filtered = [d for d in docs if _is_stock_chunk(getattr(d, "page_content", ""))]
-    doc_context = "\n\n".join(d.page_content for d in filtered[:30] if d.page_content)
+    print(f"[DEBUG] 필터링 후 문서 수: {len(filtered)}")
 
+    # 본문 + 메타데이터 기반 context 구성
+    doc_context = "\n\n".join(
+        f"[{d.metadata.get('date','')}] {d.metadata.get('title','')}\n{d.page_content[:300]}..."
+        for d in filtered[:30] if d.page_content
+    )
+
+    # 프롬프트 입력
     prompt_input = {"patterns": "", "documents": doc_context, "question": req.message}
     raw = rag.rag_chain.invoke(prompt_input)
+
     answer = raw.split("###답변:")[-1].strip() if "###답변:" in raw else raw.strip()
     answer = _postprocess_chatty(answer)
 
+    # 출처 URL 배열
     sources: List[str] = []
     for d in filtered:
         meta = getattr(d, "metadata", {}) or {}
-        src = meta.get("source") or meta.get("url")
+        src = meta.get("source")
         if src and src not in sources:
             sources.append(src)
 
-    return ChatResponse(answer=answer, sources=sources, latency_ms=int((time.time() - t0) * 1000))
+    return ChatResponse(
+        answer=answer,
+        sources=sources,
+        latency_ms=int((time.time() - t0) * 1000)
+    )

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -7,16 +7,28 @@ from app.ml.collect_url import extract_keywords, get_news_for_keywords
 from newspaper import Article
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 
-
+# 주가/거래/공시 같은 금융 키워드 + 주요 기업/산업 키워드가 있으면 통과
 def _is_stock_chunk(text: str) -> bool:
     if not text:
         return False
-    keys = [
+
+    finance_keys = [
         "주가","공시","실적","거래량","상한가","하한가","배당",
         "증자","감자","자사주","리포트","목표가","투자의견",
         "코스피","코스닥","나스닥","m&a","수주","신제품"
     ]
-    return any(k in text.lower() for k in keys)
+    company_keys = [
+        "삼성","LG","현대","SK","네이버","카카오","테슬라","애플",
+        "엔비디아","MS","구글","아마존"
+    ]
+    sector_keys = [
+        "AI","반도체","바이오","전기차","로봇","2차전지","클라우드","디스플레이"
+    ]
+
+    keys = finance_keys + company_keys + sector_keys
+    t = text.lower()
+    return any(k.lower() in t for k in keys)
+
 
 def _clean_title(title: str) -> str:
     """뉴스 제목에서 HTML 태그 제거"""

--- a/app/services/rag_service.py
+++ b/app/services/rag_service.py
@@ -98,6 +98,10 @@ async def process_chat(req: ChatRequest, user_id: str) -> ChatResponse:
     filtered = [d for d in docs if _is_stock_chunk(getattr(d, "page_content", ""))]
     print(f"[DEBUG] 필터링 후 문서 수: {len(filtered)}")
 
+    # 답변 생성할 때 참고할 뉴스 문서가 0개라면 상위 3개를 fallback으로 사용
+    if not filtered and docs:
+        filtered = docs[:3]
+
     # 본문 + 메타데이터 기반 context 구성
     doc_context = "\n\n".join(
         f"[{d.metadata.get('date','')}] {d.metadata.get('title','')}\n{d.page_content[:300]}..."


### PR DESCRIPTION
## 관련 이슈
- closed #5 

## Summary
Chat API 응답이 최신 뉴스를 반영하도록 카드뉴스 데이터 수집 로직과 연결

## 구현 내용
_fetch_and_store_news에서 네이버 뉴스 → 본문 파싱 → 청크 분할 후 벡터스토어 저장
Chat API 응답 시 벡터스토어에서 문서 검색 → 메타데이터 포함된 뉴스 문서를 기반으로 RAG 답변 생성
응답에 참조한 뉴스 URL 목록(sources) 반환